### PR TITLE
Use `std::thread::available_parallelism`

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        rust: [nightly, beta, stable, 1.49.0]
+        rust: [nightly, beta, stable, 1.59.0]
     steps:
       - uses: actions/checkout@v2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ documentation = "https://docs.rs/async-global-executor"
 keywords = ["async", "await", "future", "executor"]
 categories = ["asynchronous", "concurrency"]
 readme = "README.md"
+rust-version = "1.59"
 
 [features]
 default = ["async-io"]
@@ -24,7 +25,6 @@ async-executor = "^1.4"
 async-lock = "^2.5"
 blocking = "^1.0"
 futures-lite = "^1.0"
-num_cpus = "^1.13"
 once_cell = "^1.4"
 
 [dependencies.async-io]

--- a/src/config.rs
+++ b/src/config.rs
@@ -64,7 +64,7 @@ impl GlobalExecutorConfig {
             .ok()
             .and_then(|threads| threads.parse().ok())
             .or(self.min_threads)
-            .unwrap_or_else(num_cpus::get)
+            .unwrap_or_else(|| std::thread::available_parallelism().map_or(1, usize::from))
             .max(1);
         let max_threads = self.max_threads.unwrap_or(min_threads * 4).max(min_threads);
         Config {


### PR DESCRIPTION
As of Rust 1.59, `std::thread::available_parallelism` provides comparable
functionality to num_cpus, without requiring a dependency.
