### PR TITLE
Use `async-lock` instead of `async-mutex`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ tokio03 = ["tokio03-crate"]
 [dependencies]
 async-channel = "^1.5"
 async-executor = "^1.4"
-async-mutex = "^1.4"
+async-lock = "^2.5"
 blocking = "^1.0"
 futures-lite = "^1.0"
 num_cpus = "^1.13"

--- a/src/threading.rs
+++ b/src/threading.rs
@@ -1,6 +1,6 @@
 use crate::Task;
 use async_channel::{Receiver, Sender};
-use async_mutex::Mutex;
+use async_lock::Mutex;
 use futures_lite::future;
 use once_cell::sync::OnceCell;
 use std::{io, thread};


### PR DESCRIPTION
`async-mutex` has been replaced by `async-lock`, so it should be changed here as well so that this crate gets future updates to `async-lock`.