### PR TITLE
Limit blocking dependency to 1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ tokio03 = ["tokio03-crate"]
 async-channel = "^1.5"
 async-executor = "^1.4"
 async-lock = "^2.5"
-blocking = "^1.0"
+blocking = "^1.2"
 futures-lite = "^1.0"
 once_cell = "^1.4"
 


### PR DESCRIPTION
In executor.rs there's [code][0] that expects `blocking::unblock` to be sync
but in version prior to 1.2 it was `async.

[0]: https://github.com/async-rs/async-global-executor/blob/b5dcd0426deda80d26009436c5fe5418ee23c71a/src/executor.rs#L101
