### PR TITLE
feat: use `async_executor::StaticExecutor`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ tokio03 = ["tokio03-crate"]
 
 [dependencies]
 async-channel = "^2.1.1"
-async-executor = "^1.8"
+async-executor = { version = "^1.12", features = ["static"] }
 async-lock = "^3.2"
 blocking = "^1.5"
 futures-lite = "^2.0"

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,11 +1,11 @@
 use crate::Task;
-use async_executor::{Executor, LocalExecutor};
+use async_executor::{LocalExecutor, StaticExecutor};
 use std::future::Future;
 
-pub(crate) static GLOBAL_EXECUTOR: Executor<'_> = Executor::new();
+pub(crate) static GLOBAL_EXECUTOR: StaticExecutor = StaticExecutor::new();
 
 thread_local! {
-    pub(crate) static LOCAL_EXECUTOR: LocalExecutor<'static> = LocalExecutor::new();
+    pub(crate) static LOCAL_EXECUTOR: LocalExecutor<'static> = const { LocalExecutor::new() };
 }
 
 /// Runs the global and the local executor on the current thread

--- a/src/threading.rs
+++ b/src/threading.rs
@@ -13,7 +13,7 @@ static GLOBAL_EXECUTOR_EXPECTED_THREADS_NUMBER: Mutex<usize> = Mutex::new(0);
 thread_local! {
     // Used to shutdown a thread when we receive a message from the Sender.
     // We send an ack using to the Receiver once we're finished shutting down.
-    static THREAD_SHUTDOWN: OnceCell<(Sender<()>, Receiver<()>)> = OnceCell::new();
+    static THREAD_SHUTDOWN: OnceCell<(Sender<()>, Receiver<()>)> = const { OnceCell::new() };
 }
 
 /// Spawn more executor threads, up to configured max value.


### PR DESCRIPTION
The [`StaticExecutor`](https://github.com/smol-rs/async-executor/blob/master/src/static_executors.rs#L112-L128) type introduced in [async-executor@1.12](https://github.com/smol-rs/async-executor/releases/tag/v1.12.0) seems well suited for the async-global-executor use case, so this PR adopts that optimization.

My initial intent was also to adopt [`StaticLocalExecutor`](https://github.com/smol-rs/async-executor/blob/master/src/static_executors.rs#L297-L309) but I'm unclear on the intended usage of that type[^1] and so it was left for future work.

[^1]: [`StaticLocalExecutor::spawn`](https://github.com/smol-rs/async-executor/blob/master/src/static_executors.rs#L344-L366) requires a `'static` thread local lifetime, but `LocalKey` intentionally avoids surfacing `'static` lifetimes.

Thanks!